### PR TITLE
Adds PlayResult constructor and date formatter used for favorite trac…

### DIFF
--- a/KEXPPower.xcodeproj/project.pbxproj
+++ b/KEXPPower.xcodeproj/project.pbxproj
@@ -739,6 +739,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 0.11;
 				PRODUCT_BUNDLE_IDENTIFIER = org.kexp.KEXPPowerExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -758,6 +759,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 0.11;
 				PRODUCT_BUNDLE_IDENTIFIER = org.kexp.KEXPPowerExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/KEXPPower/Helpers/DateFormatter+StandardFormatters.swift
+++ b/KEXPPower/Helpers/DateFormatter+StandardFormatters.swift
@@ -56,4 +56,12 @@ extension DateFormatter {
         formatter.timeZone = NSTimeZone.local
         return formatter
     }()
+    
+    public static let displayFormatterWithDate: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        formatter.timeZone = NSTimeZone.local
+        return formatter
+    }()
 }

--- a/KEXPPower/Models/KEXP/PlayResult.swift
+++ b/KEXPPower/Models/KEXP/PlayResult.swift
@@ -82,6 +82,34 @@ public enum PlayType: String, Decodable {
 }
 
 extension Play {
+    
+    public init(id: Int, song: String?, artist: String?, album: String?, label: String?, airDate: Date?, comment: String?) {
+        self.id = id
+        self.uri = nil
+        self.show = nil
+        self.showURI = nil
+        self.imageURI = nil
+        self.thumbnailURI = nil
+        self.comment = comment
+        self.playType = nil
+        self.song = song
+        self.trackID = nil
+        self.recordingID = nil
+        self.artist = artist
+        self.artistIDs = []
+        self.album = album
+        self.releaseID = nil
+        self.releaseGroupID = nil
+        self.labels = label != nil ? [label!] : []
+        self.labelIDs = []
+        self.releaseDate = nil
+        self.rotationStatus = nil
+        self.isLocal = true
+        self.isRequest = false
+        self.isLive = false
+        self.airdate = airDate
+    }
+    
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         

--- a/KEXPPower/Models/KEXP/PlayResult.swift
+++ b/KEXPPower/Models/KEXP/PlayResult.swift
@@ -82,7 +82,6 @@ public enum PlayType: String, Decodable {
 }
 
 extension Play {
-    
     public init(id: Int, song: String?, artist: String?, album: String?, label: String?, airDate: Date?, comment: String?) {
         self.id = id
         self.uri = nil

--- a/KEXPPowerExample/Info.plist
+++ b/KEXPPowerExample/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
…k display in KEXP-iOS-App

These are the changes added in error to pod files in the app, PR https://github.com/KEXP/KEXP-iOS-App/pull/196/files

Seems strange that this didn't surface sooner for other people... only after `pod deintegrate` and reinstall did I repro the issue. I assume that an automated CICD pipeline would have broken immediately.