### PR TITLE
Add missing equal sign for live stream `listenerId` query param value

### DIFF
--- a/KEXPPower/Public API/AvailableStreams.swift
+++ b/KEXPPower/Public API/AvailableStreams.swift
@@ -14,9 +14,9 @@ class AvailableStreams {
     init(with listenerId: UUID) {
         var livePlaybackDict = [KEXPPower.StreamingBitRate: URL]()
         
-        livePlaybackDict[KEXPPower.StreamingBitRate.thirtyTwo] = URL(string: "https://kexp-mp3-32.streamguys1.com/kexp32.mp3?listenerId\(listenerId.uuidString)")!
-        livePlaybackDict[KEXPPower.StreamingBitRate.sixtyFour] = URL(string: "https://kexp-aacPlus-64.streamguys1.com/kexp64.aac?listenerId\(listenerId.uuidString)")!
-        livePlaybackDict[KEXPPower.StreamingBitRate.oneTwentyEight] = URL(string: "https://kexp-mp3-128.streamguys1.com/kexp128.mp3?listenerId\(listenerId.uuidString)")!
+        livePlaybackDict[KEXPPower.StreamingBitRate.thirtyTwo] = URL(string: "https://kexp-mp3-32.streamguys1.com/kexp32.mp3?listenerId=\(listenerId.uuidString)")!
+        livePlaybackDict[KEXPPower.StreamingBitRate.sixtyFour] = URL(string: "https://kexp-aacPlus-64.streamguys1.com/kexp64.aac?listenerId=\(listenerId.uuidString)")!
+        livePlaybackDict[KEXPPower.StreamingBitRate.oneTwentyEight] = URL(string: "https://kexp-mp3-128.streamguys1.com/kexp128.mp3?listenerId=\(listenerId.uuidString)")!
         
         livePlayback = livePlaybackDict
     }

--- a/KEXPPower/Public API/KEXPPower.swift
+++ b/KEXPPower/Public API/KEXPPower.swift
@@ -57,7 +57,7 @@ public class KEXPPower {
         let availableStreams = AvailableStreams(with: KEXPPower.sharedInstance.listenerId)
         
         return availableStreams.livePlayback[KEXPPower.sharedInstance.selectedBitRate] ??
-            URL(string: "https://kexp-mp3-128.streamguys1.com/kexp128.mp3?listenerId\(listenerId.uuidString)")!
+            URL(string: "https://kexp-mp3-128.streamguys1.com/kexp128.mp3?listenerId=\(listenerId.uuidString)")!
     }
     
     static func getShowURL(with showId: String) -> URL {


### PR DESCRIPTION
This PR is a small fix to make sure that the `listenerId` is appended to the various live stream URLs in the correct query param syntax.  Without this, we weren't actually passing `listenerId` onto StreamGuys.  

This treatment wasn't needed for the Archive streams, as we use a `URLQueryItem` instead of constructing the whole URL from a string literal.