### PR TITLE
Adding new URL endpoints

### DIFF
--- a/KEXPPower/Public API/AvailableStreams.swift
+++ b/KEXPPower/Public API/AvailableStreams.swift
@@ -14,9 +14,8 @@ class AvailableStreams {
     init(with listenerId: UUID) {
         var livePlaybackDict = [KEXPPower.StreamingBitRate: URL]()
         
-        livePlaybackDict[KEXPPower.StreamingBitRate.thirtyTwo] = URL(string: "https://kexp-mp3-32.streamguys1.com/kexp32.mp3?listenerId=\(listenerId.uuidString)")!
-        livePlaybackDict[KEXPPower.StreamingBitRate.sixtyFour] = URL(string: "https://kexp-aacPlus-64.streamguys1.com/kexp64.aac?listenerId=\(listenerId.uuidString)")!
-        livePlaybackDict[KEXPPower.StreamingBitRate.oneTwentyEight] = URL(string: "https://kexp-mp3-128.streamguys1.com/kexp128.mp3?listenerId=\(listenerId.uuidString)")!
+        livePlaybackDict[KEXPPower.StreamingBitRate.sixtyFour] = URL(string: "https://kexp.streamguys1.com/kexp64-hls/playlist.m3u8?listenerId=\(listenerId.uuidString)")!
+        livePlaybackDict[KEXPPower.StreamingBitRate.oneSixty] = URL(string: "https://kexp.streamguys1.com/kexp160-hls/playlist.m3u8 ?listenerId=\(listenerId.uuidString)")!
         
         livePlayback = livePlaybackDict
     }

--- a/KEXPPower/Public API/AvailableStreams.swift
+++ b/KEXPPower/Public API/AvailableStreams.swift
@@ -15,7 +15,7 @@ class AvailableStreams {
         var livePlaybackDict = [KEXPPower.StreamingBitRate: URL]()
         
         livePlaybackDict[KEXPPower.StreamingBitRate.sixtyFour] = URL(string: "https://kexp.streamguys1.com/kexp64-hls/playlist.m3u8?listenerId=\(listenerId.uuidString)")!
-        livePlaybackDict[KEXPPower.StreamingBitRate.oneSixty] = URL(string: "https://kexp.streamguys1.com/kexp160-hls/playlist.m3u8 ?listenerId=\(listenerId.uuidString)")!
+        livePlaybackDict[KEXPPower.StreamingBitRate.oneSixty] = URL(string: "https://kexp.streamguys1.com/kexp160-hls/playlist.m3u8?listenerId=\(listenerId.uuidString)")!
         
         livePlayback = livePlaybackDict
     }

--- a/KEXPPower/Public API/KEXPPower.swift
+++ b/KEXPPower/Public API/KEXPPower.swift
@@ -12,9 +12,8 @@ import Foundation
 public class KEXPPower {
     /// Available archive bit rates
     public enum StreamingBitRate: Int {
-        case thirtyTwo
         case sixtyFour
-        case oneTwentyEight
+        case oneSixty
     }
     
     /// Singleton access to KEXPower
@@ -57,7 +56,7 @@ public class KEXPPower {
         let availableStreams = AvailableStreams(with: KEXPPower.sharedInstance.listenerId)
         
         return availableStreams.livePlayback[KEXPPower.sharedInstance.selectedBitRate] ??
-            URL(string: "https://kexp-mp3-128.streamguys1.com/kexp128.mp3?listenerId=\(listenerId.uuidString)")!
+            URL(string: "https://kexp.streamguys1.com/kexp64-hls/playlist.m3u8?listenerId=\(listenerId.uuidString)")!
     }
     
     static func getShowURL(with showId: String) -> URL {

--- a/KEXPPowerExample/AppDelegate.swift
+++ b/KEXPPowerExample/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         KEXPPower.sharedInstance.setup(
             kexpBaseURL: "https://api.kexp.org",
-            selectedBitRate: KEXPPower.StreamingBitRate.oneTwentyEight
+            selectedBitRate: KEXPPower.StreamingBitRate.sixtyFour
         )
 
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To configure `KEXPPower`, call the KEXPPower `setup` method in your application'
 ```swift
 KEXPPower.sharedInstance.setup(
     kexpBaseURL: kexpBaseURL,
-    selectedBitRate: StreamingBitRate.thirtyTwo
+    selectedBitRate: StreamingBitRate.sixtyFour
 )
 ```
 


### PR DESCRIPTION
Added new URL's that replace the old AAC and MP3 ones. New 64k and 160k HLS enabled added. Also removed references to 32 and 128 as those will be retired. 