### PR TITLE
Updated to non-HLS endpoints

### DIFF
--- a/KEXPPower/Public API/AvailableStreams.swift
+++ b/KEXPPower/Public API/AvailableStreams.swift
@@ -14,8 +14,8 @@ class AvailableStreams {
     init(with listenerId: UUID) {
         var livePlaybackDict = [KEXPPower.StreamingBitRate: URL]()
         
-        livePlaybackDict[KEXPPower.StreamingBitRate.sixtyFour] = URL(string: "https://kexp.streamguys1.com/kexp64-hls/playlist.m3u8?listenerId=\(listenerId.uuidString)")!
-        livePlaybackDict[KEXPPower.StreamingBitRate.oneSixty] = URL(string: "https://kexp.streamguys1.com/kexp160-hls/playlist.m3u8?listenerId=\(listenerId.uuidString)")!
+        livePlaybackDict[KEXPPower.StreamingBitRate.sixtyFour] = URL(string: "https://kexp.streamguys1.com/kexp64.aac?listenerId=\(listenerId.uuidString)")!
+        livePlaybackDict[KEXPPower.StreamingBitRate.oneSixty] = URL(string: "https://kexp.streamguys1.com/kexp160.aac?listenerId=\(listenerId.uuidString)")!
         
         livePlayback = livePlaybackDict
     }


### PR DESCRIPTION
**OVERVIEW**
Removed the HLS encoded streams and replaced with non-HLS. This was due to the streams stopping in the app due to HLS overhead. 

**RESOLVED**
Resolves https://github.com/KEXP/KEXPPower/issues/24