### PR TITLE
Non-HLS URL Endpoints

### DIFF
--- a/KEXPPower/Documentation/Publishing KEXPPower
+++ b/KEXPPower/Documentation/Publishing KEXPPower
@@ -1,4 +1,4 @@
-Publishing KEXPPower Cocoapod
+## Publishing KEXPPower Cocoapod
 
 1) Checkout the main branch of KEXPower
     - git checkout main
@@ -23,6 +23,14 @@ Publishing KEXPPower Cocoapod
     - pod update KEXPPower
 
 
+## Updating the iOS Applications
+
+1) Open the root directory of the project in a Terminal window
+
+2) Verify that the Podfile exists at this location. 
+
+3) Run the following in Terminal
+    - pod update KEXPPower
 
 Semantic Versioning Notes
 Major.Minor.Patch

--- a/KEXPPower/Documentation/Publishing KEXPPower
+++ b/KEXPPower/Documentation/Publishing KEXPPower
@@ -7,7 +7,7 @@
     - git pull
     
 3) Update version in appropriate areas following Semantic Versioning: Major.Minor.Patch
-    - Target: Martketing Version (KEXPower => Build Settings => Marketing Version)
+    - Target: Martketing Version (KEXPower project => Build Settings => Marketing Version)
     - Podspec: s.version (KEXPPower => KEXPPower.podspec => s.version)
     
 4) Tag KEXPPower

--- a/KEXPPower/Documentation/Publishing KEXPPower
+++ b/KEXPPower/Documentation/Publishing KEXPPower
@@ -7,7 +7,7 @@
     - git pull
     
 3) Update version in appropriate areas following Semantic Versioning: Major.Minor.Patch
-    - Target: Martketing Version (KEXPower project => Build Settings => Marketing Version)
+    - Target: Martketing Version (KEXPower project => KEXPPower Target => Build Settings => Marketing Version)
     - Podspec: s.version (KEXPPower => KEXPPower.podspec => s.version)
     
 4) Tag KEXPPower

--- a/KEXPPower/Public API/AvailableStreams.swift
+++ b/KEXPPower/Public API/AvailableStreams.swift
@@ -14,8 +14,8 @@ class AvailableStreams {
     init(with listenerId: UUID) {
         var livePlaybackDict = [KEXPPower.StreamingBitRate: URL]()
         
-        livePlaybackDict[KEXPPower.StreamingBitRate.sixtyFour] = URL(string: "https://kexp.streamguys1.com/kexp64.aac?listenerId=\(listenerId.uuidString)")!
-        livePlaybackDict[KEXPPower.StreamingBitRate.oneSixty] = URL(string: "https://kexp.streamguys1.com/kexp160.aac?listenerId=\(listenerId.uuidString)")!
+        livePlaybackDict[KEXPPower.StreamingBitRate.sixtyFour] = URL(string: "https://kexp.streamguys1.com/kexp64-hls/playlist.m3u8?listenerId=\(listenerId.uuidString)")!
+        livePlaybackDict[KEXPPower.StreamingBitRate.oneSixty] = URL(string: "https://kexp.streamguys1.com/kexp160-hls/playlist.m3u8?listenerId=\(listenerId.uuidString)")!
         
         livePlayback = livePlaybackDict
     }


### PR DESCRIPTION
**OVERVIEW**  
Removed the HLS encoded streams and replaced with non-HLS. This was due to the streams stopping in the app due to HLS overhead.

**RESOLVED**  
Resolves [#24](https://github.com/KEXP/KEXPPower/issues/24)