### PR TITLE
New streaming url endpoints

### DIFF
--- a/KEXPPower/Public API/AvailableStreams.swift
+++ b/KEXPPower/Public API/AvailableStreams.swift
@@ -14,9 +14,9 @@ class AvailableStreams {
     init(with listenerId: UUID) {
         var livePlaybackDict = [KEXPPower.StreamingBitRate: URL]()
         
-        livePlaybackDict[KEXPPower.StreamingBitRate.sixtyFour] = URL(string: "https://kexp.streamguys1.com/kexp64-hls/playlist.m3u8?listenerId=\(listenerId.uuidString)")!
-        livePlaybackDict[KEXPPower.StreamingBitRate.oneSixty] = URL(string: "https://kexp.streamguys1.com/kexp160-hls/playlist.m3u8?listenerId=\(listenerId.uuidString)")!
-
+        livePlaybackDict[KEXPPower.StreamingBitRate.sixtyFour] = URL(string: "https://kexp.streamguys1.com/kexp64.aac?listenerId=\(listenerId.uuidString)")!
+        livePlaybackDict[KEXPPower.StreamingBitRate.oneSixty] = URL(string: "https://kexp.streamguys1.com/kexp160.aac?listenerId=\(listenerId.uuidString)")!
+        
         livePlayback = livePlaybackDict
     }
 }


### PR DESCRIPTION
Had to fix an issue with the HLS that didn't work as expected. Rolling back to the non-HLS