### PR TITLE
Changes formattedReleaseYear access to public

### DIFF
--- a/KEXPPower/Helpers/PlayFormatters.swift
+++ b/KEXPPower/Helpers/PlayFormatters.swift
@@ -11,7 +11,7 @@ extension Play {
     /// Returns the release year followed by first album label (if any)
     /// Example: "2022 - Matador"
     /// If releaseDate is nil, returns nil
-    var formattedReleaseYear: String? {
+    public var formattedReleaseYear: String? {
         guard
             let releaseDateString = releaseDate,
             let releaseDate = DateFormatter.releaseFormatter.date(from: releaseDateString)


### PR DESCRIPTION
Forgot that default access level is `internal` when I added this earlier - made the method `public`