### PR TITLE
KEXP Radio Permissions Fix

### DIFF
--- a/KEXPPower.xcodeproj/project.pbxproj
+++ b/KEXPPower.xcodeproj/project.pbxproj
@@ -670,7 +670,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.kexp.KEXPPower;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -700,7 +700,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.kexp.KEXPPower;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/KEXPPower/Helpers/PlayFormatters.swift
+++ b/KEXPPower/Helpers/PlayFormatters.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2023 KEXP. All rights reserved.
 //
 
-extension Play {
+public extension Play {
     
     /// Returns the release year followed by first album label (if any)
     /// Example: "2022 - Matador"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Modifying the KEXPPower requires the following
 2. CocoaPod Permissions
 3. Build permissions and access to KEXP Radio project
 
-## BUILD STEPS
+## MODIFY/BUILD STEPS
 All build steps are captured in the document titled "Updating KEXPPower into KEXP Radio", available internally. The following are the high level steps covered in that document. 
 
 1. Make changes in KEXP Radio Pod files and test changes.


### PR DESCRIPTION
**OVERVIEW**
Resolves issue with KEXP Radio where a recent library update broke one of the KEXPPower modules that permission setting was PRIVATE and now set to PUBLIC

**RESOLVES**
Fixes build issues in KEXP Radio app
