### PR TITLE
Adds optional releaseDate to Play init

### DIFF
--- a/KEXPPower/Models/KEXP/PlayResult.swift
+++ b/KEXPPower/Models/KEXP/PlayResult.swift
@@ -83,7 +83,7 @@ public enum PlayType: String, Decodable {
 }
 
 extension Play {
-    public init(id: Int, song: String?, artist: String?, album: String?, label: String?, airDate: Date?, comment: String?) {
+    public init(id: Int, song: String?, artist: String?, album: String?, label: String?, airDate: Date?, comment: String?, releaseDate: String? = nil) {
         self.id = id
         self.uri = nil
         self.show = nil
@@ -102,7 +102,7 @@ extension Play {
         self.releaseGroupID = nil
         self.labels = label != nil ? [label!] : []
         self.labelIDs = []
-        self.releaseDate = nil
+        self.releaseDate = releaseDate
         self.rotationStatus = nil
         self.isLocal = true
         self.isRequest = false


### PR DESCRIPTION
**OVERVIEW**

Adds `releaseDate` to Play init, to support detail-view year/label in the KEXP app
