### PR TITLE
removed public declaration on var

### DIFF
--- a/KEXPPower/Helpers/PlayFormatters.swift
+++ b/KEXPPower/Helpers/PlayFormatters.swift
@@ -11,7 +11,7 @@ public extension Play {
     /// Returns the release year followed by first album label (if any)
     /// Example: "2022 - Matador"
     /// If releaseDate is nil, returns nil
-    public var formattedReleaseYear: String? {
+    var formattedReleaseYear: String? {
         guard
             let releaseDateString = releaseDate,
             let releaseDate = DateFormatter.releaseFormatter.date(from: releaseDateString)


### PR DESCRIPTION
**OVERVIEW**
Removes KEXPPower build issue

**RESOLVES**
Build warning in PlayFormatters.swift that `public` isn't needed twice
